### PR TITLE
Adds SessionToken to SearchOption PropTypes

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -381,6 +381,7 @@ PlacesAutocomplete.propTypes = {
     location: PropTypes.object,
     offset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     radius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    sessionToken: PropTypes.object,
     types: PropTypes.array,
   }),
   debounce: PropTypes.number,


### PR DESCRIPTION
This will allow us to pass our SessionToken as props to the component and we're already deconstructing the searchOptions object when we use getPredictions